### PR TITLE
When x and y are both interfaces, use the smaller interface

### DIFF
--- a/scopes.go
+++ b/scopes.go
@@ -164,6 +164,12 @@ func similar(x, y types.Type) bool {
 			return false
 		}
 
+		if _, ok := y.(*types.Interface); ok {
+			if len(yMethods) < len(xMethods) {
+				xMethods, yMethods = yMethods, xMethods
+			}
+		}
+
 		for _, method := range xMethods {
 			yMethod := yMethods.getByName(method.Name())
 			if yMethod == nil || !types.Identical(method.Type(), yMethod.Type()) {

--- a/testdata/result.txt
+++ b/testdata/result.txt
@@ -1,2 +1,3 @@
 testdata/testdata.go:15:3: accessing outer scope when closer var of same type exists. Did you mean r2?
 testdata/testdata.go:24:3: accessing outer scope when closer var of same type exists. Did you mean t2?
+testdata/testdata.go:89:3: accessing outer scope when closer var of same type exists. Did you mean tx?

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -69,3 +69,32 @@ func _() {
 		fmt.Println(i, j)
 	}(i)
 }
+
+type DB interface {
+	Query(x, y int) bool
+	InTX(func(TX))
+}
+
+type TX interface {
+	DB
+
+	Commit(s string) int
+}
+
+// Fails
+func _() {
+	var db DB
+
+	db.InTX(func(tx TX) {
+		db.Query(1, 2)
+	})
+}
+
+// Passes
+func _() {
+	var db DB
+
+	db.InTX(func(tx TX) {
+		tx.Query(1, 2)
+	})
+}


### PR DESCRIPTION
Until we roll out v2 of the db library everywhere, this should catch shadowed transactions